### PR TITLE
Remove debug statement

### DIFF
--- a/app/assets/javascripts/modal-dialog.js
+++ b/app/assets/javascripts/modal-dialog.js
@@ -24,7 +24,6 @@
     timeUserLastInteractedWithPage: '',
 
     bindUIElements: function () {
-      setTimeout(GOVUK.modalDialog.openDialog, 6000) //debug
 
       GOVUK.modalDialog.$openButton.on('click', function (e) {
         GOVUK.modalDialog.openDialog()


### PR DESCRIPTION
This causes some confusion when attempting to integrate the timeout script into your application