### PR TITLE
Move container selector into a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ Run `npm start`
 
 1. Include the markup from `app/views/includes/modal_dialog.html` on your page.
 
-2. The script looks for a `#content` div on the page to set the `inert` attribute. Please change this to match name of your main container in `makePageContentInert` and `removeInertFromPageContent` in `javascripts/modal-dialog.js`. This indicates the active part of the page to screenreaders.
+2. The script looks for a `#content` div on the page to set the `inert` attribute. Please change this to match name of your main container by overriding the selector property in your app
+    ~~~
+    var GOVUK = global.GOVUK || {};
+    GOVUK.modalDialog.containerSelector = '.main-content';
+    ~~~
+    This indicates the active part of the page to screenreaders.
 
 3. Include `sass/patterns/_modal-dialog.scss` as part of your SASS.
 

--- a/app/assets/javascripts/modal-dialog.js
+++ b/app/assets/javascripts/modal-dialog.js
@@ -265,8 +265,7 @@
 
           var seconds = Math.abs((timeUserLastInteractedWithPage - new Date()) / 1000)
 
-          // TO DO: use both idlemin and timemodalvisible
-          if (seconds > GOVUK.modalDialog.idleMinutesBeforeTimeOut * 60) {
+          if (seconds > (GOVUK.modalDialog.idleMinutesBeforeTimeOut + GOVUK.modalDialog.minutesTimeOutModalVisible)  * 60) {
 
         //  if (seconds > 60) {
             GOVUK.modalDialog.redirect()

--- a/app/assets/javascripts/modal-dialog.js
+++ b/app/assets/javascripts/modal-dialog.js
@@ -6,6 +6,7 @@
 
   // Modal dialog prototype
   GOVUK.modalDialog = {
+    containerSelector: '#content',
     el: document.getElementById('js-modal-dialog'),
     $el: $('#js-modal-dialog'),
     $lastFocusedEl: null,
@@ -104,17 +105,17 @@
     // Set page content to inert to indicate to screenreaders it's inactive
     // NB: This will look for #content for toggling inert state
     makePageContentInert: function () {
-      if (document.querySelector('#content')) {
-        document.querySelector('#content').inert = true
-        document.querySelector('#content').setAttribute('aria-hidden', 'true')
+      if (document.querySelector(this.containerSelector)) {
+        document.querySelector(this.containerSelector).inert = true
+        document.querySelector(this.containerSelector).setAttribute('aria-hidden', 'true')
       }
     },
     // Make page content active when modal is not open
     // NB: This will look for #content for toggling inert state
     removeInertFromPageContent: function () {
-      if (document.querySelector('#content')) {
-        document.querySelector('#content').inert = false
-        document.querySelector('#content').setAttribute('aria-hidden', 'false')
+      if (document.querySelector(this.containerSelector)) {
+        document.querySelector(this.containerSelector).inert = false
+        document.querySelector(this.containerSelector).setAttribute('aria-hidden', 'false')
       }
     },
     // Starts a timer. If modal not closed before time out + 4 seconds grace period, user is redirected.

--- a/app/assets/javascripts/modal-dialog.js
+++ b/app/assets/javascripts/modal-dialog.js
@@ -7,6 +7,9 @@
   // Modal dialog prototype
   GOVUK.modalDialog = {
     containerSelector: '#content',
+    redirectWarningMessage: 'You are about to be redirected',
+    keepYouSecureMessage: 'We do this to keep your information secure.',
+    warningMessage: 'We will reset your application if you do not respond in',
     el: document.getElementById('js-modal-dialog'),
     $el: $('#js-modal-dialog'),
     $lastFocusedEl: null,
@@ -25,7 +28,6 @@
     timeUserLastInteractedWithPage: '',
 
     bindUIElements: function () {
-      setTimeout(GOVUK.modalDialog.openDialog, 6000) //debug
 
       GOVUK.modalDialog.$openButton.on('click', function (e) {
         GOVUK.modalDialog.openDialog()
@@ -157,8 +159,8 @@
 
           // Below string will get read out by screen readers every time the timeout refreshes (every 15 secs. See below).
           // Please add additional information in the modal body content or in below extraText which will get announced to AT the first time the time out opens
-          var text = 'We will reset your application if you do not respond in ' + minutesText + secondsText + '.'
-          var atText = 'We will reset your application if you do not respond in ' + atMinutesText
+          var text = GOVUK.modalDialog.warningMessage +  ' ' + minutesText + secondsText + '.'
+          var atText = GOVUK.modalDialog.warningMessage +  ' ' + atMinutesText
           if (atSecondsText) {
             if (minutesLeft > 0) {
               atText += ' and'
@@ -167,11 +169,11 @@
           } else {
             atText += '.'
           }
-          var extraText = ' We do this to keep your information secure.'
+          var extraText = ' ' + GOVUK.modalDialog.keepYouSecureMessage;
 
           if (timerExpired) {
-            $timer.text('You are about to be redirected')
-            $accessibleTimer.text('You are about to be redirected')
+            $timer.text(GOVUK.modalDialog.redirectWarningMessage)
+            $accessibleTimer.text(GOVUK.modalDialog.redirectWarningMessage)
             //TO DO: tell server to reset userlastinteractedwithpage
             if (window.localStorage) {
               window.localStorage.setItem('timeUserLastInteractedWithPage', '')


### PR DESCRIPTION
- Move container selector into a property so that it can overridden when needed without modifying the script
- Make timeout warning message as properties so that they can be overridden without changing file